### PR TITLE
Feature/add documentation

### DIFF
--- a/Horiba.Sdk.Tests/ChargedCoupleDeviceTestFixture.cs
+++ b/Horiba.Sdk.Tests/ChargedCoupleDeviceTestFixture.cs
@@ -1,0 +1,21 @@
+﻿namespace Horiba.Sdk.Tests;
+
+public class ChargedCoupleDeviceTestFixture : IDisposable
+{
+    public readonly ChargedCoupledDevice Ccd;
+    public readonly DeviceManager Dm;
+    
+    public ChargedCoupleDeviceTestFixture()
+    {
+        Dm = new DeviceManager();
+        Dm.StartAsync().Wait();
+        Ccd = Dm.ChargedCoupledDevices.First();
+        Ccd.OpenConnectionAsync().Wait();
+    }
+    
+    public void Dispose()
+    {
+        Ccd.CloseConnectionAsync().Wait();
+        Dm.StopAsync().Wait();
+    }
+}

--- a/Horiba.Sdk.Tests/ChargedCoupleDeviceTests.cs
+++ b/Horiba.Sdk.Tests/ChargedCoupleDeviceTests.cs
@@ -2,23 +2,24 @@
 
 namespace Horiba.Sdk.Tests;
 
-public class ChargedCoupleDeviceTests
+public class ChargedCoupleDeviceTests : IClassFixture<ChargedCoupleDeviceTestFixture>
 {
+    private readonly ChargedCoupleDeviceTestFixture _fixture;
+
+    public ChargedCoupleDeviceTests(ChargedCoupleDeviceTestFixture fixture)
+    {
+        _fixture = fixture;
+    }
+    
     [Theory]
     [InlineData(Gain.HighLight)]
     [InlineData(Gain.BestDynamicRange)]
     [InlineData(Gain.HighSensitivity)]
     public async Task GivenCcd_WhenTriggeringSetGainMethod_ThenGainIsSet(Gain expectedSetting)
     {
-        // Arrange
-        var dm = new DeviceManager();
-        await dm.StartAsync();
-        var ccd = dm.ChargedCoupledDevices.First();
-        await ccd.OpenConnectionAsync();
-
         // Act
-        await ccd.SetGainAsync(expectedSetting);
-        var actualSetting = await ccd.GetGainAsync();
+        await _fixture.Ccd.SetGainAsync(expectedSetting);
+        var actualSetting = await _fixture.Ccd.GetGainAsync();
 
         // Assert
         actualSetting.Should().HaveSameValueAs(expectedSetting);
@@ -28,15 +29,11 @@ public class ChargedCoupleDeviceTests
     public async Task GivenCcd_WhenTriggeringSetFitParameters_ThenFitParametersAreSet()
     {
         // Arrange
-        var dm = new DeviceManager();
-        await dm.StartAsync();
-        var ccd = dm.ChargedCoupledDevices.First();
-        await ccd.OpenConnectionAsync();
         var expectedParams = "1,1,1,1";
 
         // Act
-        await ccd.SetFitParametersAsync(expectedParams);
-        var actual = await ccd.GetFitParametersAsync();
+        await _fixture.Ccd.SetFitParametersAsync(expectedParams);
+        var actual = await _fixture.Ccd.GetFitParametersAsync();
 
         // Assert
         actual.Should().BeSameAs(expectedParams);
@@ -46,20 +43,17 @@ public class ChargedCoupleDeviceTests
     public async Task GivenCcd_WhenGettingActualData_ThenReturnsByteData()
     {
         // Arrange
-        var dm = new DeviceManager();
-        await dm.StartAsync();
-        var ccd = dm.ChargedCoupledDevices.First();
-        await ccd.OpenConnectionAsync();
-        await ccd.SetAcquisitionCountAsync(1);
-        await ccd.SetXAxisConversionTypeAsync(ConversionType.None);
-        await ccd.SetExposureTimeAsync(1000);
-        await ccd.SetRegionOfInterestAsync(RegionOfInterest.Default);
+        await _fixture.Ccd.OpenConnectionAsync();
+        await _fixture.Ccd.SetAcquisitionCountAsync(1);
+        await _fixture.Ccd.SetXAxisConversionTypeAsync(ConversionType.None);
+        await _fixture.Ccd.SetExposureTimeAsync(1000);
+        await _fixture.Ccd.SetRegionOfInterestAsync(RegionOfInterest.Default);
         
         // Act
-        var isReady = await ccd.GetAcquisitionReadyAsync();
-        await ccd.SetAcquisitionStartAsync(true);
-        await ccd.WaitForDeviceNotBusy();
-        var data = await ccd.GetAcquisitionDataAsync();
+        var isReady = await _fixture.Ccd.GetAcquisitionReadyAsync();
+        await _fixture.Ccd.SetAcquisitionStartAsync(true);
+        await _fixture.Ccd.WaitForDeviceNotBusy();
+        var data = await _fixture.Ccd.GetAcquisitionDataAsync();
 
         // Assert
         data.MatchSnapshot();
@@ -70,14 +64,9 @@ public class ChargedCoupleDeviceTests
     [Fact]
     public async Task GivenCcd_WhenOpeningConnection_ThenConnectionIsOpened()
     {
-        // Arrange
-        var dm = new DeviceManager();
-        await dm.StartAsync();
-        var ccd = dm.ChargedCoupledDevices.First();
-        
         // Act
-        await ccd.OpenConnectionAsync();
-        var actualStatus = await ccd.IsConnectionOpenedAsync();
+        await _fixture.Ccd.OpenConnectionAsync();
+        var actualStatus = await _fixture.Ccd.IsConnectionOpenedAsync();
 
         // Assert
         actualStatus.Should().BeTrue();
@@ -86,15 +75,10 @@ public class ChargedCoupleDeviceTests
     [Fact]
     public async Task GivenCcd_WhenOpeningAndClosingConnection_ThenConnectionIsClosed()
     {
-        // Arrange
-        var dm = new DeviceManager();
-        await dm.StartAsync();
-        var ccd = dm.ChargedCoupledDevices.First();
-        
         // Act
-        await ccd.OpenConnectionAsync();
-        await ccd.CloseConnectionAsync();
-        var actualStatus = await ccd.IsConnectionOpenedAsync();
+        await _fixture.Ccd.OpenConnectionAsync();
+        await _fixture.Ccd.CloseConnectionAsync();
+        var actualStatus = await _fixture.Ccd.IsConnectionOpenedAsync();
 
         // Assert
         actualStatus.Should().BeFalse();
@@ -106,15 +90,9 @@ public class ChargedCoupleDeviceTests
     [InlineData(Speed.Fast)]
     public async Task GivenCcd_WhenSettingSpeed_ThenSpeedIsUpdated(Speed targetSpeed)
     {
-        // Arrange
-        var dm = new DeviceManager();
-        await dm.StartAsync();
-        var ccd = dm.ChargedCoupledDevices.First();
-        await ccd.OpenConnectionAsync();
-        
         // Act
-        await ccd.SetSpeedAsync(targetSpeed);
-        var speed = await ccd.GetSpeedAsync();
+        await _fixture.Ccd.SetSpeedAsync(targetSpeed);
+        var speed = await _fixture.Ccd.GetSpeedAsync();
 
         // Assert
         speed.Should().Be(targetSpeed);
@@ -124,15 +102,11 @@ public class ChargedCoupleDeviceTests
     public async Task GivenCcd_WhenSettingExposureTime_ThenSetsExposureTimeCorrectly()
     {
         // Arrange
-        var dm = new DeviceManager();
-        await dm.StartAsync();
-        var ccd = dm.ChargedCoupledDevices.First();
-        await ccd.OpenConnectionAsync();
         var time = 1234;
         
         // Act
-        await ccd.SetExposureTimeAsync(time);
-        var actualTime = await ccd.GetExposureTimeAsync();
+        await _fixture.Ccd.SetExposureTimeAsync(time);
+        var actualTime = await _fixture.Ccd.GetExposureTimeAsync();
 
         // Assert
         actualTime.Should().Be(time);
@@ -142,15 +116,11 @@ public class ChargedCoupleDeviceTests
     public async Task GivenCcd_WhenSettingXAxisConversionType_ThenSetsXAxisConversionType()
     {
         // Arrange
-        var dm = new DeviceManager();
-        await dm.StartAsync();
-        var ccd = dm.ChargedCoupledDevices.First();
-        await ccd.OpenConnectionAsync();
         var targetConversionType = ConversionType.FromCcdFirmware;
 
         // Act
-        await ccd.SetXAxisConversionTypeAsync(targetConversionType);
-        var actual = await ccd.GetXAxisConversionTypeAsync();
+        await _fixture.Ccd.SetXAxisConversionTypeAsync(targetConversionType);
+        var actual = await _fixture.Ccd.GetXAxisConversionTypeAsync();
         
         // Assert
         actual.Should().Be(targetConversionType);
@@ -160,15 +130,11 @@ public class ChargedCoupleDeviceTests
     public async Task GivenCcd_WhenSettingNumberOfAverages_ThenSetsTheNumberOfAverages()
     {
         // Arrange
-        var dm = new DeviceManager();
-        await dm.StartAsync();
-        var ccd = dm.ChargedCoupledDevices.First();
-        await ccd.OpenConnectionAsync();
         var targetNumber = 5;
 
         // Act
-        await ccd.SetNumberOfAveragesAsync(targetNumber);
-        var actual = await ccd.GetNumberOfAveragesAsync();
+        await _fixture.Ccd.SetNumberOfAveragesAsync(targetNumber);
+        var actual = await _fixture.Ccd.GetNumberOfAveragesAsync();
 
         // Assert
         actual.Should().Be(targetNumber);
@@ -178,15 +144,11 @@ public class ChargedCoupleDeviceTests
     public async Task GivenCcd_WhenSettingTimeResolution_ThenSetsTheTimeResolution()
     {
         // Arrange
-        var dm = new DeviceManager();
-        await dm.StartAsync();
-        var ccd = dm.ChargedCoupledDevices.First();
-        await ccd.OpenConnectionAsync();
         var targetResolution = 500;
 
         // Act
-        await ccd.SetTimerResolutionAsync(targetResolution);
-        var actual = await ccd.GetTimerResolutionAsync();
+        await _fixture.Ccd.SetTimerResolutionAsync(targetResolution);
+        var actual = await _fixture.Ccd.GetTimerResolutionAsync();
 
         // Assert
         actual.Should().Be(targetResolution);
@@ -196,15 +158,11 @@ public class ChargedCoupleDeviceTests
     public async Task GivenCcd_WhenSettingAcquisitionCount_ThenSetsTheAcquisitionCount()
     {
         // Arrange
-        var dm = new DeviceManager();
-        await dm.StartAsync();
-        var ccd = dm.ChargedCoupledDevices.First();
-        await ccd.OpenConnectionAsync();
         var targetCount = 5;
 
         // Act
-        await ccd.SetAcquisitionCountAsync(targetCount);
-        var actual = await ccd.GetAcquisitionCountAsync();
+        await _fixture.Ccd.SetAcquisitionCountAsync(targetCount);
+        var actual = await _fixture.Ccd.GetAcquisitionCountAsync();
 
         // Assert
         actual.Should().Be(targetCount);
@@ -213,15 +171,9 @@ public class ChargedCoupleDeviceTests
     [Fact]
     public async Task GivenCcd_WhenSettingCleanCount_ThenSetsCleanCount()
     {
-        // Arrange
-        var dm = new DeviceManager();
-        await dm.StartAsync();
-        var ccd = dm.ChargedCoupledDevices.First();
-        await ccd.OpenConnectionAsync();
-
         // Act
-        await ccd.SetCleanCountAsync(5, CleanCountMode.Mode1);
-        var actual = await ccd.GetCleanCountAsync();
+        await _fixture.Ccd.SetCleanCountAsync(5, CleanCountMode.Mode1);
+        var actual = await _fixture.Ccd.GetCleanCountAsync();
 
         // Assert
         actual.MatchSnapshot();
@@ -230,14 +182,8 @@ public class ChargedCoupleDeviceTests
     [Fact]
     public async Task GivenCcd_WhenReadingDeviceConfiguration_ThenReturnsConsistentDeviceConfiguration()
     {
-        // Arrange
-        var dm = new DeviceManager();
-        await dm.StartAsync();
-        var ccd = dm.ChargedCoupledDevices.First();
-        await ccd.OpenConnectionAsync();
-        
         // Act
-        var cofig = await ccd.GetDeviceConfigurationAsync();
+        var cofig = await _fixture.Ccd.GetDeviceConfigurationAsync();
 
         // Assert
         cofig.MatchSnapshot();
@@ -246,14 +192,8 @@ public class ChargedCoupleDeviceTests
     [Fact]
     public async Task GivenCcd_WhenGettingChipSize_ThenReturnsConsistentSize()
     {
-        // Arrange
-        var dm = new DeviceManager();
-        await dm.StartAsync();
-        var ccd = dm.ChargedCoupledDevices.First();
-        await ccd.OpenConnectionAsync();
-        
         // Act
-        var size = await ccd.GetChipSizeAsync();
+        var size = await _fixture.Ccd.GetChipSizeAsync();
 
         // Assert
         size.MatchSnapshot();
@@ -262,14 +202,8 @@ public class ChargedCoupleDeviceTests
     [Fact]
     public async Task GivenCcd_WhenGettingChipTemperature_ThenReturnsConsistentTemperature()
     {
-        // Arrange
-        var dm = new DeviceManager();
-        await dm.StartAsync();
-        var ccd = dm.ChargedCoupledDevices.First();
-        await ccd.OpenConnectionAsync();
-        
         // Act
-        var temp = await ccd.GetChipTemperatureAsync();
+        var temp = await _fixture.Ccd.GetChipTemperatureAsync();
 
         // Assert
         temp.Should().BeApproximately(-60, 0.1f);

--- a/Horiba.Sdk.Tests/ChargedCoupleDeviceTests.cs
+++ b/Horiba.Sdk.Tests/ChargedCoupleDeviceTests.cs
@@ -58,10 +58,8 @@ public class ChargedCoupleDeviceTests : IClassFixture<ChargedCoupleDeviceTestFix
         // Assert
         data.MatchSnapshot();
     }
-    
-    // TODO test procedure get picture, move mono, get picture again
 
-    [Fact]
+    [Fact(Skip = "It should be tested separately")]
     public async Task GivenCcd_WhenOpeningConnection_ThenConnectionIsOpened()
     {
         // Act
@@ -72,7 +70,7 @@ public class ChargedCoupleDeviceTests : IClassFixture<ChargedCoupleDeviceTestFix
         actualStatus.Should().BeTrue();
     }
 
-    [Fact]
+    [Fact(Skip = "It should be tested separately")]
     public async Task GivenCcd_WhenOpeningAndClosingConnection_ThenConnectionIsClosed()
     {
         // Act

--- a/Horiba.Sdk.Tests/DeviceManagerTests.cs
+++ b/Horiba.Sdk.Tests/DeviceManagerTests.cs
@@ -66,4 +66,18 @@ public class DeviceManagerTests
         // Assert
         expectedException.Should().NotBeNull();
     }
+
+    [Fact]
+    public async Task GivenNewDeviceManager_WhenGettingIclInfo_ThenReturnsConsistentResult()
+    {
+        // Arrange
+        using var deviceManager = new DeviceManager();
+        await deviceManager.StartAsync();
+        
+        // Act
+        var info = await deviceManager.GetIclInfoAsync();
+
+        // Assert
+        info.MatchSnapshot();
+    }
 }

--- a/Horiba.Sdk.Tests/MonochromatorTestFixture.cs
+++ b/Horiba.Sdk.Tests/MonochromatorTestFixture.cs
@@ -1,0 +1,24 @@
+﻿namespace Horiba.Sdk.Tests;
+
+public class MonochromatorTestFixture : IDisposable
+{
+    public readonly DeviceManager Dm;
+    public readonly MonochromatorDevice Mono;
+    
+    public MonochromatorTestFixture()
+    {
+        Dm = new DeviceManager();
+        Dm.StartAsync().Wait();
+        Mono = Dm.Monochromators.First();
+        Mono.OpenConnectionAsync().Wait();
+        Mono.HomeAsync().Wait();
+        Mono.WaitForDeviceNotBusy().Wait();
+        Task.Delay(TimeSpan.FromSeconds(10)).Wait();
+    }
+
+    public void Dispose()
+    {
+        Mono.CloseConnectionAsync().Wait();
+        Dm.StopAsync().Wait();
+    }
+}

--- a/Horiba.Sdk.Tests/MonochromatorTests.cs
+++ b/Horiba.Sdk.Tests/MonochromatorTests.cs
@@ -57,17 +57,14 @@ public class MonochromatorTests : IClassFixture<MonochromatorTestFixture>
     {
         // Act
         await _fixture.Mono.SetTurretGratingAsync(target);
-        
-        //TODO make sure there is enough time for the device to move a grating
-        await _fixture.Mono.WaitForDeviceNotBusy();
-        
+        await _fixture.Mono.WaitForDeviceNotBusy(30000);
         var actual = await _fixture.Mono.GetTurretGratingAsync();
 
         // Assert
         actual.Should().Be(target);
     }
 
-    [Theory]
+    [Theory(Skip = "The available device does not have a wheel installed. Hardware feature is missing")]
     [InlineData(FilterWheelPosition.Red)]
     [InlineData(FilterWheelPosition.Green)]
     [InlineData(FilterWheelPosition.Blue)]
@@ -91,6 +88,7 @@ public class MonochromatorTests : IClassFixture<MonochromatorTestFixture>
     {
         // Act
         await _fixture.Mono.SetMirrorPositionAsync(mirror, target);
+        await _fixture.Mono.WaitForDeviceNotBusy(5000);
         var actual = await _fixture.Mono.GetMirrorPosition(mirror);
 
         // Assert
@@ -138,7 +136,7 @@ public class MonochromatorTests : IClassFixture<MonochromatorTestFixture>
     {
         // Act
         await _fixture.Mono.SetSlitStepPositionAsync(slit, targetPosition);
-        await _fixture.Mono.WaitForDeviceNotBusy();
+        await _fixture.Mono.WaitForDeviceNotBusy(5000);
         var actual = await _fixture.Mono.GetSlitStepPositionAsync(slit);
 
         // Assert

--- a/Horiba.Sdk.Tests/MonochromatorTests.cs
+++ b/Horiba.Sdk.Tests/MonochromatorTests.cs
@@ -110,7 +110,7 @@ public class MonochromatorTests : IClassFixture<MonochromatorTestFixture>
     {
         // Act
         await _fixture.Mono.SetSlitPositionAsync(slit, targetPosition);
-        await _fixture.Mono.WaitForDeviceNotBusy();
+        await _fixture.Mono.WaitForDeviceNotBusy(5000);
         var actual = await _fixture.Mono.GetSlitPositionInMMAsync(slit);
 
         // Assert

--- a/Horiba.Sdk.Tests/__snapshots__/DeviceManagerTests.GivenNewDeviceManager_WhenGettingIclInfo_ThenReturnsConsistentResult.snap
+++ b/Horiba.Sdk.Tests/__snapshots__/DeviceManagerTests.GivenNewDeviceManager_WhenGettingIclInfo_ThenReturnsConsistentResult.snap
@@ -1,0 +1,8 @@
+﻿{
+  "nodeAlias": "ICL",
+  "nodeApiVersion": 300,
+  "nodeBuilt": "Apr  4 2024-08:53:20",
+  "nodeDescription": "Instrument Control Library",
+  "nodeId": 1,
+  "nodeVersion": "2.0.0.124.b4cc4e55"
+}

--- a/Horiba.Sdk/Commands/MonoCommands.cs
+++ b/Horiba.Sdk/Commands/MonoCommands.cs
@@ -114,7 +114,7 @@ internal record MonoMoveMirrorCommand(int DeviceId, Mirror Mirror, MirrorPositio
     : MonochromatorDeviceCommand("mono_moveMirror", new Dictionary<string, object>
     {
         { "index", DeviceId },
-        { "id", (int)Mirror },
+        { "type", (int)Mirror },
         { "position", (int)MirrorPosition }
     })
 {

--- a/Horiba.Sdk/Commands/MonoCommands.cs
+++ b/Horiba.Sdk/Commands/MonoCommands.cs
@@ -23,7 +23,7 @@ internal record MonoIsBusyCommand(int DeviceId) : MonochromatorDeviceCommand("mo
     public int DeviceId { get; } = DeviceId;
 }
 
-internal record MonoHomeCommand(int DeviceId) : MonochromatorDeviceCommand("mono_init", DeviceId)
+internal record MonoInitCommand(int DeviceId) : MonochromatorDeviceCommand("mono_init", DeviceId)
 {
     public int DeviceId { get; } = DeviceId;
 }

--- a/Horiba.Sdk/Communication/ChargedCoupleDeviceCommand.cs
+++ b/Horiba.Sdk/Communication/ChargedCoupleDeviceCommand.cs
@@ -1,5 +1,9 @@
 ﻿namespace Horiba.Sdk.Communication;
 
+/// <summary>
+/// A dedicated abstraction used to group device specific commands.
+/// Only commands targeting a ChargedCoupleDevice should derive from this class.
+/// </summary>
 public abstract record ChargedCoupleDeviceCommand : Command
 {
     protected ChargedCoupleDeviceCommand(string commandName, int deviceId) :

--- a/Horiba.Sdk/Communication/Command.cs
+++ b/Horiba.Sdk/Communication/Command.cs
@@ -2,6 +2,10 @@
 
 namespace Horiba.Sdk.Communication;
 
+/// <summary>
+/// Abstraction which defines the essential structure of the TCP communication.
+/// It also takes care of generating sequential Ids for every command sent using the <see cref="WebSocketCommunicator"/>  
+/// </summary>
 public abstract record Command
 {
     private static int _initialCommandId;

--- a/Horiba.Sdk/Communication/MonochromatorDeviceCommand.cs
+++ b/Horiba.Sdk/Communication/MonochromatorDeviceCommand.cs
@@ -1,5 +1,9 @@
 ﻿namespace Horiba.Sdk.Communication;
 
+/// <summary>
+/// A dedicated abstraction used to group device specific commands.
+/// Only commands targeting a MonochromatorDevice should derive from this class.
+/// </summary>
 public abstract record MonochromatorDeviceCommand : Command
 {
     protected MonochromatorDeviceCommand(string commandName, int deviceId) :

--- a/Horiba.Sdk/Communication/Response.cs
+++ b/Horiba.Sdk/Communication/Response.cs
@@ -2,6 +2,13 @@
 
 namespace Horiba.Sdk.Communication;
 
+/// <summary>
+/// Represents a response coming from the ICL
+/// </summary>
+/// <param name="Id">The id of the command this response is for</param>
+/// <param name="CommandName">The name of the command this response is for</param>
+/// <param name="Results">The results caused by triggering the command</param>
+/// <param name="Errors">The errors the command caused</param>
 public sealed record Response(int Id, string CommandName, Dictionary<string, object> Results, List<string> Errors)
 {
     [JsonProperty("id")] public int Id { get; set; } = Id;

--- a/Horiba.Sdk/Communication/SingleChanelDetectorCommand.cs
+++ b/Horiba.Sdk/Communication/SingleChanelDetectorCommand.cs
@@ -1,5 +1,9 @@
 ﻿namespace Horiba.Sdk.Communication;
 
+/// <summary>
+/// A dedicated abstraction used to group device specific commands.
+/// Only commands targeting a SingleChanelDetector should derive from this class.
+/// </summary>
 public abstract record SingleChanelDetectorCommand : Command
 {
     protected SingleChanelDetectorCommand(string commandName, Dictionary<string, object> parameters) : base(commandName,

--- a/Horiba.Sdk/Communication/WebSocketCommunicator.cs
+++ b/Horiba.Sdk/Communication/WebSocketCommunicator.cs
@@ -6,6 +6,14 @@ using Serilog;
 
 namespace Horiba.Sdk.Communication;
 
+/// <summary>
+/// Encapsulates the communication between ICL and the SDK. This class is responsible for sending, receiving and logging
+/// all commands sent to and from the ICL.
+/// This class should not be used on its own. <see cref="Horiba.Sdk.Devices.DeviceManager"/> Is responsible for creating it.
+/// All devices are using the same instance of the <see cref="WebSocketCommunicator"/> once generated.
+/// </summary>
+/// <param name="ipAddress">The IP address of the machine running the ICL process. Defaults to 127.0.0.1</param>
+/// <param name="port">The port on which the ICL expects communication to happen. Defaults to </param>
 public sealed class WebSocketCommunicator(IPAddress ipAddress, int port)
 {
     private readonly ClientWebSocket _wsClient = new();

--- a/Horiba.Sdk/Devices/ChargedCoupledDevice.cs
+++ b/Horiba.Sdk/Devices/ChargedCoupledDevice.cs
@@ -38,10 +38,11 @@ public sealed record ChargedCoupledDevice(
     /// <summary>
     /// Waits for the device to complete an acquisition
     /// </summary>
-    /// <param name="waitIntervalInMs">Defines how long will a waiting cycle lasts</param>
     /// <param name="initialWaitInMs">Defines the time before the waiting cycle begins</param>
+    /// <param name="waitIntervalInMs">Defines how long will a waiting cycle lasts</param>
     /// <param name="cancellationToken"></param>
-    public override async Task WaitForDeviceNotBusy(int waitIntervalInMs = 500, int initialWaitInMs = 500, CancellationToken cancellationToken = default)
+    public override async Task WaitForDeviceNotBusy(int initialWaitInMs = 250, int waitIntervalInMs = 250,
+        CancellationToken cancellationToken = default)
     {
         Task.Delay(initialWaitInMs, cancellationToken).Wait(cancellationToken);
         while (await GetAcquisitionBusyAsync(cancellationToken))

--- a/Horiba.Sdk/Devices/Device.cs
+++ b/Horiba.Sdk/Devices/Device.cs
@@ -12,6 +12,6 @@ public abstract record Device(int DeviceId, string DeviceType, string SerialNumb
     public abstract Task<bool> IsConnectionOpenedAsync(CancellationToken cancellationToken = default);
     public abstract Task OpenConnectionAsync(CancellationToken cancellationToken = default);
     public abstract Task CloseConnectionAsync(CancellationToken cancellationToken = default);
-    public abstract Task WaitForDeviceNotBusy(int waitIntervalInMs, int initialWaitInMs,
+    public abstract Task WaitForDeviceNotBusy(int initialWaitInMs, int waitIntervalInMs, 
         CancellationToken cancellationToken = default);
 }

--- a/Horiba.Sdk/Devices/DeviceManager.cs
+++ b/Horiba.Sdk/Devices/DeviceManager.cs
@@ -84,6 +84,12 @@ public sealed class DeviceManager : IDisposable
         ChargedCoupledDevices = await new ChargedCoupleDeviceDiscovery(Communicator).DiscoverDevicesAsync(cancellationToken);
     }
 
+    public async Task<string> GetIclInfoAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await Communicator.SendWithResponseAsync(new IclInfoCommand(), cancellationToken);
+        return result.Results["info"].ToString();
+    }
+
     private void IclProcessOnExited(object sender, EventArgs e)
     {
         Log.Debug("ICL process terminated");

--- a/Horiba.Sdk/Devices/MonochromatorDevice.cs
+++ b/Horiba.Sdk/Devices/MonochromatorDevice.cs
@@ -48,10 +48,11 @@ public sealed record MonochromatorDevice(
     /// <summary>
     /// Waits for the device to complete an acquisition
     /// </summary>
-    /// <param name="waitIntervalInMs">Defines how long will a waiting cycle lasts</param>
     /// <param name="initialWaitInMs">Defines the time before the waiting cycle begins</param>
+    /// <param name="waitIntervalInMs">Defines how long will a waiting cycle lasts</param>
     /// <param name="cancellationToken"></param>
-    public override async Task WaitForDeviceNotBusy(int waitIntervalInMs = 1500, int initialWaitInMs = 500, CancellationToken cancellationToken = default)
+    public override async Task WaitForDeviceNotBusy(int initialWaitInMs = 500, int waitIntervalInMs = 500,
+        CancellationToken cancellationToken = default)
     {
         Task.Delay(initialWaitInMs, cancellationToken).Wait(cancellationToken);
         while (await IsDeviceBusyAsync(cancellationToken))

--- a/Horiba.Sdk/Devices/MonochromatorDevice.cs
+++ b/Horiba.Sdk/Devices/MonochromatorDevice.cs
@@ -30,6 +30,8 @@ public sealed record MonochromatorDevice(
     /// <returns></returns>
     public override Task OpenConnectionAsync(CancellationToken cancellationToken = default)
     {
+        //TODO accept a bool parameter to stop the mono_init from executing
+        //TODO expose public method to allow sending mono_init separately
         return Communicator.SendAsync(new MonoOpenCommand(DeviceId), cancellationToken);
     }
 
@@ -79,7 +81,7 @@ public sealed record MonochromatorDevice(
     /// <returns></returns>
     public Task HomeAsync(CancellationToken cancellationToken = default)
     {
-        return Communicator.SendAsync(new MonoHomeCommand(DeviceId), cancellationToken);
+        return Communicator.SendAsync(new MonoInitCommand(DeviceId), cancellationToken);
     }
 
     /// <summary>

--- a/Horiba.Sdk/Devices/SingleChannelDetectorDevice.cs
+++ b/Horiba.Sdk/Devices/SingleChannelDetectorDevice.cs
@@ -24,7 +24,8 @@ public sealed record SingleChannelDetectorDevice(
         throw new NotImplementedException();
     }
 
-    public override Task WaitForDeviceNotBusy(int waitIntervalInMs, int initialWaitInMs, CancellationToken cancellationToken = default)
+    public override Task WaitForDeviceNotBusy(int initialWaitInMs, int waitIntervalInMs,
+        CancellationToken cancellationToken = default)
     {
         throw new NotImplementedException();
     }

--- a/icl_command_status.md
+++ b/icl_command_status.md
@@ -34,8 +34,8 @@
 | mono_shutterOpen            |      ✅      |        ✅        |   ⛔    |     [E];-519;Mono must be configured for internal shutter mode     |
 | mono_shutterClose           |      ✅      |        ✅        |   ⛔    |     [E];-519;Mono must be configured for internal shutter mode     |
 | mono_getShutterStatus       |      ✅      |        ✅        |   ⚠️    |                                                                    |
-| mono_getSlitStepPosition    |      ✅      |        ✅        |   ⚠️    |                                                                    |
-| mono_moveSlit               |      ✅      |        ✅        |   ⛔    | does not work, sometimes the device gets disconnected from USB bus |
+| mono_getSlitStepPosition    |      ✅      |        ✅        |   ✅    |                                                                    |
+| mono_moveSlit               |      ✅      |        ✅        |   ⛔    |                        Slit C is not moving                        |
 
 # CCD Commands
 

--- a/icl_command_status.md
+++ b/icl_command_status.md
@@ -8,81 +8,81 @@
 
 # Monochromator Commands
 
-| Command                     | Implemented | Tests available | Status |                              Comment                               |
-| --------------------------- | :---------: | :-------------: | :----: | :----------------------------------------------------------------: |
-| mono_discover               |      ✅      |        ✅        |   ✅    |                                                                    |
-| mono_list                   |      ✅      |        ✅        |   ✅    |                                                                    |
-| mono_listCount              |      ✖️      |        ✖️        |   ✖️    |                                                                    |
-| mono_open                   |      ✅      |        ✅        |   ✅    |                                                                    |
-| mono_close                  |      ✅      |        ✅        |   ✅    |                                                                    |
-| mono_isOpen                 |      ✅      |        ✅        |   ✅    |                                                                    |
-| mono_isBusy                 |      ✅      |        ✅        |   ✅    |                                                                    |
-| mono_init                   |      ✅      |        ✖️        |   ✖️    |                                                                    |
-| mono_getConfig              |      ✅      |        ✅        |   ✅    |                                                                    |
-| mono_getPosition            |      ✅      |        ✅        |   ✅    |                                                                    |
-| mono_setPosition            |      ✅      |        ✖️        |   ✖️    |            This operation will un-calibrate the device             |
-| mono_moveToPosition         |      ✅      |        ✅        |   ✅    |                                                                    |
-| mono_getGratingPosition     |      ✅      |        ✅        |   ⚠️    |                                                                    |
-| mono_moveGrating            |      ✅      |        ✅        |   ⛔    |                           does not work                            |
-| mono_getFilterWheelPosition |      ✅      |        ✅        |   ⚠️    |                                                                    |
-| mono_moveFilterWheel        |      ✅      |        ✅        |   ⛔    |             [E];-510;Error Mono Command Not Supported              |
-| mono_getMirrorPosition      |      ✅      |        ✅        |   ⚠️    |                                                                    |
-| mono_moveMirror             |      ✅      |        ✅        |   ⛔    |                 Second mirror cannot move literal                  |
-| mono_getSlitPositionInMM    |      ✅      |        ✅        |   ⚠️    |                                                                    |
-| mono_moveSlitMM             |      ✅      |        ✅        |   ⛔    | does not work, sometimes the device gets disconnected from USB bus |
-| mono_shutterSelect          |      ✖️      |        ✖️        |   ✖️    |                                                                    |
-| mono_shutterOpen            |      ✅      |        ✅        |   ⛔    |     [E];-519;Mono must be configured for internal shutter mode     |
-| mono_shutterClose           |      ✅      |        ✅        |   ⛔    |     [E];-519;Mono must be configured for internal shutter mode     |
-| mono_getShutterStatus       |      ✅      |        ✅        |   ⚠️    |                                                                    |
-| mono_getSlitStepPosition    |      ✅      |        ✅        |   ✅    |                                                                    |
-| mono_moveSlit               |      ✅      |        ✅        |   ⛔    |                        Slit C is not moving                        |
+| Command                     | Implemented | Tests available | Status |                                          Comment                                          |
+| --------------------------- | :---------: | :-------------: | :----: | :---------------------------------------------------------------------------------------: |
+| mono_discover               |      ✅      |        ✅        |   ✅    |                                                                                           |
+| mono_list                   |      ✅      |        ✅        |   ✅    |                                                                                           |
+| mono_listCount              |      ✖️      |        ✖️        |   ✖️    |                                                                                           |
+| mono_open                   |      ✅      |        ✅        |   ✅    |                                                                                           |
+| mono_close                  |      ✅      |        ✅        |   ✅    |                                                                                           |
+| mono_isOpen                 |      ✅      |        ✅        |   ✅    |                                                                                           |
+| mono_isBusy                 |      ✅      |        ✅        |   ✅    |                                                                                           |
+| mono_init                   |      ✅      |        ✅        |   ⚠️    | There is no way to reliably understand if a homing cycle was done after the last power-up |
+| mono_getConfig              |      ✅      |        ✅        |   ✅    |                                                                                           |
+| mono_getPosition            |      ✅      |        ✅        |   ✅    |                                                                                           |
+| mono_setPosition            |      ✅      |        ✖️        |   ⚠️    |                        This operation will un-calibrate the device                        |
+| mono_moveToPosition         |      ✅      |        ✅        |   ✅    |                                                                                           |
+| mono_getGratingPosition     |      ✅      |        ✅        |   ✅    |                                                                                           |
+| mono_moveGrating            |      ✅      |        ✅        |   ⛔    |                     Grating does not move even after 30s waiting time                     |
+| mono_getFilterWheelPosition |      ✅      |        ✅        |   ⚠️    |                                                                                           |
+| mono_moveFilterWheel        |      ✅      |        ✅        |   ⛔    |                         [E];-510;Error Mono Command Not Supported                         |
+| mono_getMirrorPosition      |      ✅      |        ✅        |   ✅    |                                                                                           |
+| mono_moveMirror             |      ✅      |        ✅        |   ⛔    |                        First and Second mirror cannot move literal                        |
+| mono_getSlitPositionInMM    |      ✅      |        ✅        |   ✅    |                                                                                           |
+| mono_moveSlitMM             |      ✅      |        ✅        |   ⛔    |                                   Slit C is not moving                                    |
+| mono_shutterSelect          |      ✖️      |        ✖️        |   ✖️    |                                                                                           |
+| mono_shutterOpen            |      ✅      |        ✅        |   ⛔    |                [E];-519;Mono must be configured for internal shutter mode                 |
+| mono_shutterClose           |      ✅      |        ✅        |   ⛔    |                [E];-519;Mono must be configured for internal shutter mode                 |
+| mono_getShutterStatus       |      ✅      |        ✅        |   ⚠️    |                                                                                           |
+| mono_getSlitStepPosition    |      ✅      |        ✅        |   ✅    |                                                                                           |
+| mono_moveSlit               |      ✅      |        ✅        |   ⛔    |                                   Slit C is not moving                                    |
 
 # CCD Commands
 
-| Command                    | Implemented | Tests available | Status |                 Comment                 |
-| -------------------------- | :---------: | :-------------: | :----: | :-------------------------------------: |
-| ccd_discover               |      ✅      |        ✅        |   ✅    |                                         |
-| ccd_list                   |      ✅      |        ✅        |   ✅    |                                         |
-| ccd_listCount              |      ✖️      |        ✖️        |   ✖️    |                                         |
-| ccd_open                   |      ✅      |        ✅        |   ✅    |                                         |
-| ccd_close                  |      ✅      |        ✅        |   ✅    |                                         |
-| ccd_isOpen                 |      ✅      |        ✅        |   ✅    |                                         |
-| ccd_restart                |      ✅      |        ✖️        |   ✖️    |         how can this be tested          |
-| ccd_getConfig              |      ✅      |        ✅        |   ✅    |                                         |
-| ccd_getChipSize            |      ✅      |        ✅        |   ✅    |                                         |
-| ccd_getChipTemperature     |      ✅      |        ✅        |   ✅    |                                         |
-| ccd_getNumberOfAvgs        |      ✅      |        ✅        |   ⚠️    |                                         |
-| ccd_setNumberOfAvgs        |      ✅      |        ✅        |   ⛔    | [E];-315;CCD does not support averaging |
-| ccd_getGain                |      ✅      |        ✅        |   ✅    |                                         |
-| ccd_setGain                |      ✅      |        ✅        |   ✅    |                                         |
-| ccd_getSpeed               |      ✅      |        ✅        |   ✅    |                                         |
-| ccd_setSpeed               |      ✅      |        ✅        |   ✅    |                                         |
-| ccd_getFitParams           |      ✅      |        ✅        |   ⚠️    |                                         |
-| ccd_setFitParams           |      ✅      |        ✅        |   ⛔    |   how should these parameters be used   |
-| ccd_getExposureTime        |      ✅      |        ✅        |   ✅    |                                         |
-| ccd_setExposureTime        |      ✅      |        ✅        |   ✅    |                                         |
-| ccd_getTimerResolution     |      ✅      |        ✅        |   ⚠️    |                                         |
-| ccd_setTimerResolution     |      ✅      |        ✅        |   ⛔    |  when set to 500 or 5000, returns 1000  |
-| ccd_setAcqFormat           |      ✅      |        ✖️        |   ✖️    |         how can this be tested          |
-| ccd_setRoi                 |      ✅      |        ✖️        |   ✖️    |         how can this be tested          |
-| ccd_getXAxisConversionType |      ✅      |        ✅        |   ✅    |                                         |
-| ccd_setXAxisConversionType |      ✅      |        ✅        |   ✅    |                                         |
-| ccd_getDataRetrievalMethod |      ✖️      |        ✖️        |   ✖️    |                                         |
-| ccd_setDataRetrievalMethod |      ✖️      |        ✖️        |   ✖️    |                                         |
-| ccd_getAcqCount            |      ✅      |        ✅        |   ⚠️    |                                         |
-| ccd_setAcqCount            |      ✅      |        ✅        |   ⛔    |       when set to 5, returns 1000       |
-| ccd_getCleanCount          |      ✅      |        ✅        |   ✅    |                                         |
-| ccd_setCleanCount          |      ✅      |        ✅        |   ✅    |                                         |
-| ccd_getDataSize            |      ✅      |        ✖️        |   ✖️    |                                         |
-| ccd_getTriggerIn           |      ✖️      |        ✖️        |   ✖️    |                                         |
-| ccd_setTriggerIn           |      ✖️      |        ✖️        |   ✖️    |                                         |
-| ccd_getSignalOut           |      ✖️      |        ✖️        |   ✖️    |                                         |
-| ccd_setSignalOut           |      ✖️      |        ✖️        |   ✖️    |                                         |
-| ccd_getAcquisitionReady    |      ✅      |        ✅        |   ⚠️    |                                         |
-| ccd_setAcquisitionStart    |      ✅      |        ✅        |   ⚠️    |                                         |
-| ccd_getAcquisitionBusy     |      ✅      |        ✅        |   ⚠️    |                                         |
-| ccd_setAcquisitionAbort    |      ✅      |        ✖️        |   ✖️    |                                         |
-| ccd_getAcquisitionData     |      ✅      |        ✅        |   ⛔    |  [E];-326;Error Data Formatting Error   |
+| Command                    | Implemented | Tests available | Status |                                            Comment                                            |
+| -------------------------- | :---------: | :-------------: | :----: | :-------------------------------------------------------------------------------------------: |
+| ccd_discover               |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_list                   |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_listCount              |      ✖️      |        ✖️        |   ✖️    |                                                                                               |
+| ccd_open                   |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_close                  |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_isOpen                 |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_restart                |      ✅      |        ✖️        |   ❓    |                            how can this be tested with code only?                             |
+| ccd_getConfig              |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_getChipSize            |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_getChipTemperature     |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_getNumberOfAvgs        |      ✅      |        ✅        |   ⚠️    | If we cannot set the parameter, how can we test the readout operation for the same parameter? |
+| ccd_setNumberOfAvgs        |      ✅      |        ✅        |   ⛔    |                            [E];-315;CCD does not support averaging                            |
+| ccd_getGain                |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_setGain                |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_getSpeed               |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_setSpeed               |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_getFitParams           |      ✅      |        ✅        |   ⚠️    | If we cannot set the parameter, how can we test the readout operation for the same parameter? |
+| ccd_setFitParams           |      ✅      |        ✅        |   ⛔    |                              how should these parameters be used                              |
+| ccd_getExposureTime        |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_setExposureTime        |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_getTimerResolution     |      ✅      |        ✅        |   ⚠️    |                                                                                               |
+| ccd_setTimerResolution     |      ✅      |        ✅        |   ⛔    |                             when set to 500 or 5000, returns 1000                             |
+| ccd_setAcqFormat           |      ✅      |        ✖️        |   ❓    |                            how can this be tested with code only?                             |
+| ccd_setRoi                 |      ✅      |        ✖️        |   ❓    |                            how can this be tested with code only?                             |
+| ccd_getXAxisConversionType |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_setXAxisConversionType |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_getDataRetrievalMethod |      ✖️      |        ✖️        |   ✖️    |                                                                                               |
+| ccd_setDataRetrievalMethod |      ✖️      |        ✖️        |   ✖️    |                                                                                               |
+| ccd_getAcqCount            |      ✅      |        ✅        |   ⚠️    |                                                                                               |
+| ccd_setAcqCount            |      ✅      |        ✅        |   ⛔    |                                  when set to 5, returns 1000                                  |
+| ccd_getCleanCount          |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_setCleanCount          |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_getDataSize            |      ✅      |        ✖️        |   ✖️    |                                                                                               |
+| ccd_getTriggerIn           |      ✖️      |        ✖️        |   ✖️    |                                                                                               |
+| ccd_setTriggerIn           |      ✖️      |        ✖️        |   ✖️    |                                                                                               |
+| ccd_getSignalOut           |      ✖️      |        ✖️        |   ✖️    |                                                                                               |
+| ccd_setSignalOut           |      ✖️      |        ✖️        |   ✖️    |                                                                                               |
+| ccd_getAcquisitionReady    |      ✅      |        ✅        |   ⚠️    |                                                                                               |
+| ccd_setAcquisitionStart    |      ✅      |        ✅        |   ⚠️    |                                                                                               |
+| ccd_getAcquisitionBusy     |      ✅      |        ✅        |   ⚠️    |                                                                                               |
+| ccd_setAcquisitionAbort    |      ✅      |        ✖️        |   ❓    |                            what is the expected 'Abort' procedure?                            |
+| ccd_getAcquisitionData     |      ✅      |        ✅        |   ⛔    |                             [E];-326;Error Data Formatting Error                              |
 
 # Single Chanel Detector Commands
 

--- a/index.md
+++ b/index.md
@@ -20,3 +20,114 @@ ___
 
 * .NET Standard or .NET 6+
 * ICL.exe installed as part of the Horiba SDK, licensed and activated
+
+
+
+
+
+# Command Status
+
+## ICL version 2.0.0.124.b4cc4e55
+---
+---
+
+# Generic Commands
+
+| Command      | Implemented | Tests available | Status | Comment |
+| ------------ | :---------: | :-------------: | :----: | :-----: |
+| icl_info     |      ✅      |        ✖️        |   ✖️    |         |
+| icl_shutdown |      ✅      |        ✖️        |   ✖️    |         |
+| icl_binMode  |      ✅      |        ✖️        |   ✖️    |         |
+
+# Monochromator Commands
+
+| Command                     | Implemented | Tests available | Status |                                          Comment                                          |
+| --------------------------- | :---------: | :-------------: | :----: | :---------------------------------------------------------------------------------------: |
+| mono_discover               |      ✅      |        ✅        |   ✅    |                                                                                           |
+| mono_list                   |      ✅      |        ✅        |   ✅    |                                                                                           |
+| mono_listCount              |      ✖️      |        ✖️        |   ✖️    |                                                                                           |
+| mono_open                   |      ✅      |        ✅        |   ✅    |                                                                                           |
+| mono_close                  |      ✅      |        ✅        |   ✅    |                                                                                           |
+| mono_isOpen                 |      ✅      |        ✅        |   ✅    |                                                                                           |
+| mono_isBusy                 |      ✅      |        ✅        |   ✅    |                                                                                           |
+| mono_init                   |      ✅      |        ✅        |   ⚠️    | There is no way to reliably understand if a homing cycle was done after the last power-up |
+| mono_getConfig              |      ✅      |        ✅        |   ✅    |                                                                                           |
+| mono_getPosition            |      ✅      |        ✅        |   ✅    |                                                                                           |
+| mono_setPosition            |      ✅      |        ✖️        |   ⚠️    |                        This operation will un-calibrate the device                        |
+| mono_moveToPosition         |      ✅      |        ✅        |   ✅    |                                                                                           |
+| mono_getGratingPosition     |      ✅      |        ✅        |   ✅    |                                                                                           |
+| mono_moveGrating            |      ✅      |        ✅        |   ⛔    |                     Grating does not move even after 30s waiting time                     |
+| mono_getFilterWheelPosition |      ✅      |        ✅        |   ⚠️    |                                                                                           |
+| mono_moveFilterWheel        |      ✅      |        ✅        |   ⛔    |                         [E];-510;Error Mono Command Not Supported                         |
+| mono_getMirrorPosition      |      ✅      |        ✅        |   ✅    |                                                                                           |
+| mono_moveMirror             |      ✅      |        ✅        |   ⛔    |                        First and Second mirror cannot move literal                        |
+| mono_getSlitPositionInMM    |      ✅      |        ✅        |   ✅    |                                                                                           |
+| mono_moveSlitMM             |      ✅      |        ✅        |   ⛔    |                                   Slit C is not moving                                    |
+| mono_shutterSelect          |      ✖️      |        ✖️        |   ✖️    |                                                                                           |
+| mono_shutterOpen            |      ✅      |        ✅        |   ⛔    |                [E];-519;Mono must be configured for internal shutter mode                 |
+| mono_shutterClose           |      ✅      |        ✅        |   ⛔    |                [E];-519;Mono must be configured for internal shutter mode                 |
+| mono_getShutterStatus       |      ✅      |        ✅        |   ⚠️    |                                                                                           |
+| mono_getSlitStepPosition    |      ✅      |        ✅        |   ✅    |                                                                                           |
+| mono_moveSlit               |      ✅      |        ✅        |   ⛔    |                                   Slit C is not moving                                    |
+
+# CCD Commands
+
+| Command                    | Implemented | Tests available | Status |                                            Comment                                            |
+| -------------------------- | :---------: | :-------------: | :----: | :-------------------------------------------------------------------------------------------: |
+| ccd_discover               |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_list                   |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_listCount              |      ✖️      |        ✖️        |   ✖️    |                                                                                               |
+| ccd_open                   |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_close                  |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_isOpen                 |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_restart                |      ✅      |        ✖️        |   ❓    |                            how can this be tested with code only?                             |
+| ccd_getConfig              |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_getChipSize            |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_getChipTemperature     |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_getNumberOfAvgs        |      ✅      |        ✅        |   ⚠️    | If we cannot set the parameter, how can we test the readout operation for the same parameter? |
+| ccd_setNumberOfAvgs        |      ✅      |        ✅        |   ⛔    |                            [E];-315;CCD does not support averaging                            |
+| ccd_getGain                |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_setGain                |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_getSpeed               |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_setSpeed               |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_getFitParams           |      ✅      |        ✅        |   ⚠️    | If we cannot set the parameter, how can we test the readout operation for the same parameter? |
+| ccd_setFitParams           |      ✅      |        ✅        |   ⛔    |                              how should these parameters be used                              |
+| ccd_getExposureTime        |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_setExposureTime        |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_getTimerResolution     |      ✅      |        ✅        |   ⚠️    |                                                                                               |
+| ccd_setTimerResolution     |      ✅      |        ✅        |   ⛔    |                             when set to 500 or 5000, returns 1000                             |
+| ccd_setAcqFormat           |      ✅      |        ✖️        |   ❓    |                            how can this be tested with code only?                             |
+| ccd_setRoi                 |      ✅      |        ✖️        |   ❓    |                            how can this be tested with code only?                             |
+| ccd_getXAxisConversionType |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_setXAxisConversionType |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_getDataRetrievalMethod |      ✖️      |        ✖️        |   ✖️    |                                                                                               |
+| ccd_setDataRetrievalMethod |      ✖️      |        ✖️        |   ✖️    |                                                                                               |
+| ccd_getAcqCount            |      ✅      |        ✅        |   ⚠️    |                                                                                               |
+| ccd_setAcqCount            |      ✅      |        ✅        |   ⛔    |                                  when set to 5, returns 1000                                  |
+| ccd_getCleanCount          |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_setCleanCount          |      ✅      |        ✅        |   ✅    |                                                                                               |
+| ccd_getDataSize            |      ✅      |        ✖️        |   ✖️    |                                                                                               |
+| ccd_getTriggerIn           |      ✖️      |        ✖️        |   ✖️    |                                                                                               |
+| ccd_setTriggerIn           |      ✖️      |        ✖️        |   ✖️    |                                                                                               |
+| ccd_getSignalOut           |      ✖️      |        ✖️        |   ✖️    |                                                                                               |
+| ccd_setSignalOut           |      ✖️      |        ✖️        |   ✖️    |                                                                                               |
+| ccd_getAcquisitionReady    |      ✅      |        ✅        |   ⚠️    |                                                                                               |
+| ccd_setAcquisitionStart    |      ✅      |        ✅        |   ⚠️    |                                                                                               |
+| ccd_getAcquisitionBusy     |      ✅      |        ✅        |   ⚠️    |                                                                                               |
+| ccd_setAcquisitionAbort    |      ✅      |        ✖️        |   ❓    |                            what is the expected 'Abort' procedure?                            |
+| ccd_getAcquisitionData     |      ✅      |        ✅        |   ⛔    |                             [E];-326;Error Data Formatting Error                              |
+
+# Single Chanel Detector Commands
+
+| Command       | Implemented | Tested | Status | Comment |
+| ------------- | :---------: | -----: | -----: | ------: |
+| scd_discover  |      ✖️      |      ✖️ |      ✖️ |         |
+| scd_list      |      ✖️      |      ✖️ |      ✖️ |         |
+| scd_listCount |      ✖️      |      ✖️ |      ✖️ |         |
+| scd_open      |      ✖️      |      ✖️ |      ✖️ |         |
+| scd_close     |      ✖️      |      ✖️ |      ✖️ |         |
+| scd_isOpen    |      ✖️      |      ✖️ |      ✖️ |         |
+
+
+---
+---


### PR DESCRIPTION
Update documentation
Implement delays in tests so that every action related to hardware movement of the monochromator device has enough time to allow the hardware to actually move